### PR TITLE
mmap.map returns SharedArrayBuffer

### DIFF
--- a/dist/mmap-io.d.ts
+++ b/dist/mmap-io.d.ts
@@ -4,7 +4,7 @@ declare type MapProtectionFlags = MmapIo["PROT_NONE"] | MmapIo["PROT_READ"] | Mm
 declare type MapFlags = MmapIo["MAP_PRIVATE"] | MmapIo["MAP_SHARED"] | MmapIo["MAP_NONBLOCK"] | MmapIo["MAP_POPULATE"] | number;
 declare type MapAdvise = MmapIo["MADV_NORMAL"] | MmapIo["MADV_RANDOM"] | MmapIo["MADV_SEQUENTIAL"] | MmapIo["MADV_WILLNEED"] | MmapIo["MADV_DONTNEED"];
 declare type MmapIo = {
-    map(size: number, protection: MapProtectionFlags, flags: MapFlags, fd: FileDescriptor, offset?: number, advise?: MapAdvise, name?: Buffer): Buffer;
+    map(size: number, protection: MapProtectionFlags, flags: MapFlags, fd: FileDescriptor, offset?: number, advise?: MapAdvise, name?: Buffer): SharedArrayBuffer;
     advise(buffer: Buffer, offset: number, length: number, advise: MapAdvise): void;
     advise(buffer: Buffer, advise: MapAdvise): void;
     incore(buffer: Buffer): [number, number];

--- a/mmap-io.d.ts
+++ b/mmap-io.d.ts
@@ -4,7 +4,7 @@ declare type MapProtectionFlags = MmapIo["PROT_NONE"] | MmapIo["PROT_READ"] | Mm
 declare type MapFlags = MmapIo["MAP_PRIVATE"] | MmapIo["MAP_SHARED"] | MmapIo["MAP_NONBLOCK"] | MmapIo["MAP_POPULATE"] | number;
 declare type MapAdvise = MmapIo["MADV_NORMAL"] | MmapIo["MADV_RANDOM"] | MmapIo["MADV_SEQUENTIAL"] | MmapIo["MADV_WILLNEED"] | MmapIo["MADV_DONTNEED"];
 declare type MmapIo = {
-    map(size: number, protection: MapProtectionFlags, flags: MapFlags, fd: FileDescriptor, offset?: number, advise?: MapAdvise, name?: Buffer): Buffer;
+    map(size: number, protection: MapProtectionFlags, flags: MapFlags, fd: FileDescriptor, offset?: number, advise?: MapAdvise, name?: Buffer): SharedArrayBuffer;
     advise(buffer: Buffer, offset: number, length: number, advise: MapAdvise): void;
     advise(buffer: Buffer, advise: MapAdvise): void;
     incore(buffer: Buffer): [number, number];

--- a/src/mmap-io.ts
+++ b/src/mmap-io.ts
@@ -49,7 +49,7 @@ type MmapIo = {
         offset?: number,
         advise?: MapAdvise,
         name?: Buffer
-    ): Buffer
+    ): SharedArrayBuffer
 
     advise(
         buffer: Buffer,


### PR DESCRIPTION
Hi @ARyaskov,

I hope you are well.

This is a pull request for an unfinished change to show PoC. The code compiles but only mmap.map works as this is the only method I adapted.

One could say mmap provides shared memory. JavaScript has a standard object for that - [SharedArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer) - that can be shared between workers. This could be helpful as it is with mmap. But there is more.

[Atomics](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics) are built-in into JavaScript and can be used over SharedArrayBuffer for synchronization between JavaScript workers. Making the buffer mmap returns SharedArrayBuffer would make this available out of the box for free. But there is more.

While atomics are formally for inter-thread synchronization (i.e. workers in JavaScript), this is merely a result of C++ standards not "knowing" about processes as far as I can tell. There is a consequential result from [the wording of the standards](https://timsong-cpp.github.io/cppwp/n4659/atomics.lockfree#4) ("This restriction enables communication by memory that is mapped into a process more than once **and by memory that is shared between two processes.**") that, as far as I can tell, guarantees that Atomics apart from notify() and wait() must work inter-process in addition to inter-thread. And they do in practice. Therefore, mmap'ing a SharedArrayBuffer would enable [very effective](https://en.cppreference.com/w/c/atomic/atomic_load) inter-process communication which opens many possibilities for interoperability not only within nodejs but between different programming languages.

Worth noting, as far as I can tell, Atomics notify() and wait() would start working inter-process as well when nodejs is recompiled for C++20 standard.

Relevant [Stack Overflow](https://stackoverflow.com/questions/13161153/c11-interprocess-atomics-and-mutexes).


That being said, I think the interface of SharedArrayBuffer is quite unpleasant for regular operations easily achievable with a Buffer, especially if you don't need the functionality described above. Maybe it's worth it for mmap package to provide both buffer return types.



Please, feel free to incorporate this idea into the package, and thank you for providing it in the first place.

I hope this helps.

WBR



P. S. As far as I can tell, nodejs cannot mmap more than 1GiB at once - check buf.byteLength after trying to map larger file, it will be exactly 1GiB. A somewhat tangential explanation of why can be found on [Stack Overflow](https://stackoverflow.com/questions/54452896/maximum-number-of-entries-in-node-js-map). Maybe worth adding a check within mmap.map for that.