### PR TITLE
Add Node.js v23, v24, and v25 support 

### DIFF
--- a/.github/workflows/publish-binary.js.yml
+++ b/.github/workflows/publish-binary.js.yml
@@ -15,7 +15,7 @@ jobs:
         build-type: [
           {os: "macos-latest", arch: "arm64"},
         ]
-        node-version: [18.x, 19.x, 20.x, 21.x, 22.x]
+        node-version: [18.x, 19.x, 20.x, 21.x, 22.x, 23.x, 24.x, 25.x]
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ facilitate reliable syncing between RAM-file and disk-file. [mmap(2)](https://li
 - **mmap-io** is written in C++17 and TypeScript, when you're installing it in your project, you're automatically getting 
 a precompiled binary (.node-file) for your platform from Downloads section of this project. 
 Otherwise it requires a C++17 compiler and Python 3.12+ on your machine to build.
-- **mmap-io** is tested on 18, 19, 20, 21, 22.
+- **mmap-io** is tested on 18, 19, 20, 21, 22, 23, 24, 25.
 - **mmap-io** has built binaries for Windows x86_64, Linux x86_64, Mac x86_64, Mac ARM.
 - Potential use cases: working with big files (like highly volatile game map files), pushing data to cache files, video/audio-processing, messaging mechanics for inter-process communication.
 

--- a/binding.gyp
+++ b/binding.gyp
@@ -6,12 +6,12 @@
             "<!(node -e \"require('nan')\")"
         ],
         "cflags_cc": [
-            "-std=c++17"
+            "-std=c++20"
         ],
         "conditions": [
             [ 'OS=="mac"',
                 { "xcode_settings": {
-                    'OTHER_CPLUSPLUSFLAGS' : ['-std=c++17','-stdlib=libc++'],
+                    'OTHER_CPLUSPLUSFLAGS' : ['-std=c++20','-stdlib=libc++'],
                     'OTHER_LDFLAGS': ['-stdlib=libc++'],
                     'MACOSX_DEPLOYMENT_TARGET': '10.8'
                 }}

--- a/dist/mmap-io.d.ts
+++ b/dist/mmap-io.d.ts
@@ -1,15 +1,14 @@
-/// <reference types="node" />
-declare type FileDescriptor = number;
-declare type MapProtectionFlags = MmapIo["PROT_NONE"] | MmapIo["PROT_READ"] | MmapIo["PROT_WRITE"] | MmapIo["PROT_EXEC"] | 3 | 5 | 6 | 7;
-declare type MapFlags = MmapIo["MAP_PRIVATE"] | MmapIo["MAP_SHARED"] | MmapIo["MAP_NONBLOCK"] | MmapIo["MAP_POPULATE"] | number;
-declare type MapAdvise = MmapIo["MADV_NORMAL"] | MmapIo["MADV_RANDOM"] | MmapIo["MADV_SEQUENTIAL"] | MmapIo["MADV_WILLNEED"] | MmapIo["MADV_DONTNEED"];
-declare type MmapIo = {
-    map(size: number, protection: MapProtectionFlags, flags: MapFlags, fd: FileDescriptor, offset?: number, advise?: MapAdvise, name?: Buffer): SharedArrayBuffer;
-    advise(buffer: Buffer, offset: number, length: number, advise: MapAdvise): void;
-    advise(buffer: Buffer, advise: MapAdvise): void;
-    incore(buffer: Buffer): [number, number];
-    sync(buffer: Buffer, offset?: number, size?: number, blocking_sync?: boolean, invalidate_pages?: boolean): void;
-    sync(buffer: Buffer, blocking_sync: boolean, invalidate_pages?: boolean): void;
+type FileDescriptor = number;
+type MapProtectionFlags = MmapIo["PROT_NONE"] | MmapIo["PROT_READ"] | MmapIo["PROT_WRITE"] | MmapIo["PROT_EXEC"] | 3 | 5 | 6 | 7;
+type MapFlags = MmapIo["MAP_PRIVATE"] | MmapIo["MAP_SHARED"] | MmapIo["MAP_NONBLOCK"] | MmapIo["MAP_POPULATE"] | number;
+type MapAdvise = MmapIo["MADV_NORMAL"] | MmapIo["MADV_RANDOM"] | MmapIo["MADV_SEQUENTIAL"] | MmapIo["MADV_WILLNEED"] | MmapIo["MADV_DONTNEED"];
+type MmapIo = {
+    map(size: number, protection: MapProtectionFlags, flags: MapFlags, fd: FileDescriptor, offset?: number, advise?: MapAdvise, name?: Buffer): Uint8Array;
+    advise(buffer: Buffer | SharedArrayBuffer | Uint8Array, offset: number, length: number, advise: MapAdvise): void;
+    advise(buffer: Buffer | SharedArrayBuffer | Uint8Array, advise: MapAdvise): void;
+    incore(buffer: Buffer | SharedArrayBuffer | Uint8Array): [number, number];
+    sync(buffer: Buffer | SharedArrayBuffer | Uint8Array, offset?: number, size?: number, blocking_sync?: boolean, invalidate_pages?: boolean): void;
+    sync(buffer: Buffer | SharedArrayBuffer | Uint8Array, blocking_sync: boolean, invalidate_pages?: boolean): void;
     readonly PROT_READ: 1;
     readonly PROT_WRITE: 2;
     readonly PROT_EXEC: 4;

--- a/dist/mmap-io.js
+++ b/dist/mmap-io.js
@@ -11,11 +11,13 @@ delete mmap_lib_raw_.sync_lib_private__;
 // Take care of all the param juggling here instead of in C++ code, by making
 // some overloads, and doing some argument defaults /ozra
 mmap_lib_raw_.sync = function (buf, par_a, par_b, par_c, par_d) {
+    // Get the buffer size - use byteLength for SharedArrayBuffer/Uint8Array, length for Buffer
+    const bufSize = (buf instanceof SharedArrayBuffer || buf instanceof Uint8Array) ? buf.byteLength : buf.length;
     if (typeof par_a === "boolean") {
-        raw_sync_fn_(buf, 0, buf.length, par_a, par_b || false);
+        raw_sync_fn_(buf, 0, bufSize, par_a, par_b || false);
     }
     else {
-        raw_sync_fn_(buf, par_a || 0, par_b || buf.length, par_c || false, par_d || false);
+        raw_sync_fn_(buf, par_a || 0, par_b || bufSize, par_c || false, par_d || false);
     }
 };
 // mmap_lib_raw_.sync = sync_

--- a/dist/test.js
+++ b/dist/test.js
@@ -28,8 +28,8 @@ fd = fs.openSync(process.argv[1], 'r');
 size = fs.fstatSync(fd).size;
 say("file size", size);
 buffer = mmap.map(size, PROT_READ, MAP_SHARED, fd, 0, mmap.MADV_SEQUENTIAL);
-say("buflen 1 = ", buffer.length);
-assert.equal(buffer.length, size);
+say("buflen 1 = ", buffer.byteLength);
+assert.equal(buffer.byteLength, size);
 say("Give advise with 2 args");
 mmap.advise(buffer, mmap.MADV_NORMAL);
 say("Give advise with 4 args");
@@ -58,16 +58,16 @@ try {
   say("deliberate out of bounds, caught exception - does this thing happen?", e.code, 'err-obj = ', e);
 }
 buffer = mmap.map(size, PROT_READ, MAP_SHARED, fd, 0);
-say("buflen test 5-arg map call = ", buffer.length);
-assert.equal(buffer.length, size);
+say("buflen test 5-arg map call = ", buffer.byteLength);
+assert.equal(buffer.byteLength, size);
 buffer = mmap.map(size, PROT_READ, MAP_SHARED, fd);
-say("buflen test 4-arg map call = ", buffer.length);
-assert.equal(buffer.length, size);
+say("buflen test 4-arg map call = ", buffer.byteLength);
+assert.equal(buffer.byteLength, size);
 if (os.type() !== 'Windows_NT') {
   fd = fs.openSync(process.argv[1], 'r');
   buffer = mmap.map(size, PROT_READ, MAP_SHARED, fd, PAGESIZE);
-  say("buflen test 3 = ", buffer.length);
-  assert.equal(buffer.length, size);
+  say("buflen test 3 = ", buffer.byteLength);
+  assert.equal(buffer.byteLength, size);
 }
 fd = fs.openSync(process.argv[1], 'r');
 try {

--- a/mmap-io.d.ts
+++ b/mmap-io.d.ts
@@ -3,12 +3,12 @@ type MapProtectionFlags = MmapIo["PROT_NONE"] | MmapIo["PROT_READ"] | MmapIo["PR
 type MapFlags = MmapIo["MAP_PRIVATE"] | MmapIo["MAP_SHARED"] | MmapIo["MAP_NONBLOCK"] | MmapIo["MAP_POPULATE"] | number;
 type MapAdvise = MmapIo["MADV_NORMAL"] | MmapIo["MADV_RANDOM"] | MmapIo["MADV_SEQUENTIAL"] | MmapIo["MADV_WILLNEED"] | MmapIo["MADV_DONTNEED"];
 type MmapIo = {
-    map(size: number, protection: MapProtectionFlags, flags: MapFlags, fd: FileDescriptor, offset?: number, advise?: MapAdvise, name?: Buffer): SharedArrayBuffer;
-    advise(buffer: Buffer, offset: number, length: number, advise: MapAdvise): void;
-    advise(buffer: Buffer, advise: MapAdvise): void;
-    incore(buffer: Buffer): [number, number];
-    sync(buffer: Buffer, offset?: number, size?: number, blocking_sync?: boolean, invalidate_pages?: boolean): void;
-    sync(buffer: Buffer, blocking_sync: boolean, invalidate_pages?: boolean): void;
+    map(size: number, protection: MapProtectionFlags, flags: MapFlags, fd: FileDescriptor, offset?: number, advise?: MapAdvise, name?: Buffer): Uint8Array;
+    advise(buffer: Buffer | SharedArrayBuffer | Uint8Array, offset: number, length: number, advise: MapAdvise): void;
+    advise(buffer: Buffer | SharedArrayBuffer | Uint8Array, advise: MapAdvise): void;
+    incore(buffer: Buffer | SharedArrayBuffer | Uint8Array): [number, number];
+    sync(buffer: Buffer | SharedArrayBuffer | Uint8Array, offset?: number, size?: number, blocking_sync?: boolean, invalidate_pages?: boolean): void;
+    sync(buffer: Buffer | SharedArrayBuffer | Uint8Array, blocking_sync: boolean, invalidate_pages?: boolean): void;
     readonly PROT_READ: 1;
     readonly PROT_WRITE: 2;
     readonly PROT_EXEC: 4;

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
             "dependencies": {
                 "@mapbox/node-pre-gyp": "^1.0.11",
                 "errno": "*",
-                "nan": "^2.20.0",
+                "nan": "^2.23.1",
                 "node-gyp": "^10.2.0",
                 "run-script-os": "^1.1.6"
             },
@@ -1515,9 +1515,10 @@
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "node_modules/nan": {
-            "version": "2.20.0",
-            "resolved": "https://registry.npmjs.org/nan/-/nan-2.20.0.tgz",
-            "integrity": "sha512-bk3gXBZDGILuuo/6sKtr0DQmSThYHLtNCdSdXk9YkxD/jK6X2vmCyyXBBxyqZ4XcnzTyYEAThfX3DCEnLf6igw=="
+            "version": "2.23.1",
+            "resolved": "https://registry.npmjs.org/nan/-/nan-2.23.1.tgz",
+            "integrity": "sha512-r7bBUGKzlqk8oPBDYxt6Z0aEdF1G1rwlMcLk8LCOMbOzf0mG+JUfUzG4fIMWwHWP0iyaLWEQZJmtB7nOHEm/qw==",
+            "license": "MIT"
         },
         "node_modules/negotiator": {
             "version": "0.6.3",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "dependencies": {
         "@mapbox/node-pre-gyp": "^1.0.11",
         "errno": "*",
-        "nan": "^2.20.0",
+        "nan": "^2.23.1",
         "node-gyp": "^10.2.0",
         "run-script-os": "^1.1.6"
     },

--- a/src/mmap-io.cc
+++ b/src/mmap-io.cc
@@ -35,6 +35,37 @@ inline int do_mmap_advice(char* addr, size_t length, int advise) {
     return madvise(static_cast<void*>(addr), length, advise);
 }
 
+// Helper function to get data pointer and size from SharedArrayBuffer or Uint8Array
+inline bool get_buffer_info(Local<Value> val, char** data_out, size_t* size_out) {
+    // Check if it's a Uint8Array (our new return type)
+    if (val->IsUint8Array()) {
+        Local<Uint8Array> arr = val.As<Uint8Array>();
+        Local<ArrayBuffer> ab = arr->Buffer();
+        std::shared_ptr<BackingStore> bs = ab->GetBackingStore();
+        *data_out = static_cast<char*>(bs->Data()) + arr->ByteOffset();
+        *size_out = arr->ByteLength();
+        return true;
+    }
+    // Check if it's a SharedArrayBuffer
+    if (val->IsSharedArrayBuffer()) {
+        Local<SharedArrayBuffer> sab = val.As<SharedArrayBuffer>();
+        std::shared_ptr<BackingStore> bs = sab->GetBackingStore();
+        *data_out = static_cast<char*>(bs->Data());
+        *size_out = bs->ByteLength();
+        return true;
+    }
+    // Fallback to Buffer API for backward compatibility
+    if (val->IsObject()) {
+        Local<Object> obj = val.As<Object>();
+        if (node::Buffer::HasInstance(obj)) {
+            *data_out = node::Buffer::Data(obj);
+            *size_out = node::Buffer::Length(obj);
+            return true;
+        }
+    }
+    return false;
+}
+
 
 /*
 
@@ -152,11 +183,13 @@ JS_FN(mmap_map) {
         }
 
         std::shared_ptr<BackingStore> backingStore = v8::SharedArrayBuffer::NewBackingStore(data, size, do_mmap_cleanup, NULL);
-        Nan::MaybeLocal<Object> buf = v8::SharedArrayBuffer::New(v8::Isolate::GetCurrent(), backingStore);
-        if (buf.IsEmpty()) {
+        v8::Local<v8::SharedArrayBuffer> sab = v8::SharedArrayBuffer::New(v8::Isolate::GetCurrent(), backingStore);
+        if (sab.IsEmpty()) {
             return Nan::ThrowError(std::string("couldn't allocate Node SharedArrayBuffer()").c_str());
         } else {
-            info.GetReturnValue().Set(buf.ToLocalChecked());
+            // Create a Uint8Array view over the SharedArrayBuffer for Buffer-like API
+            v8::Local<v8::Uint8Array> view = v8::Uint8Array::New(sab, 0, size);
+            info.GetReturnValue().Set(view);
         }
     }
 }
@@ -172,9 +205,11 @@ JS_FN(mmap_advise) {
     if (!info[0]->IsObject())    return Nan::ThrowError("advice(): buffer (arg[0]) must be a Buffer");
     if (!info[1]->IsNumber())    return Nan::ThrowError("advice(): (arg[1]) must be an integer");
 
-    Local<Object>   buf     = get_obj(info[0]); // info[0]->ToObject(); // get_v<Local<Object>>(info[0]);
-    char*           data    = node::Buffer::Data(buf);
-    size_t          size    = node::Buffer::Length(buf);
+    char*   data;
+    size_t  size;
+    if (!get_buffer_info(info[0], &data, &size)) {
+        return Nan::ThrowError("advise(): buffer (arg[0]) must be a Buffer or SharedArrayBuffer");
+    }
 
     int ret = ([&]() -> int {
         if (info.Length() == 2) {
@@ -207,9 +242,11 @@ JS_FN(mmap_incore) {
 
     if (!info[0]->IsObject())    return Nan::ThrowError("advice(): buffer (arg[0]) must be a Buffer");
 
-    Local<Object>   buf     = get_obj(info[0]); // info[0]->ToObject(); // get_v<Local<Object>>(info[0]);
-    char*           data    = node::Buffer::Data(buf);
-    size_t          size    = node::Buffer::Length(buf);
+    char*   data;
+    size_t  size;
+    if (!get_buffer_info(info[0], &data, &size)) {
+        return Nan::ThrowError("incore(): buffer (arg[0]) must be a Buffer or SharedArrayBuffer");
+    }
 
 #ifdef _WIN32
     SYSTEM_INFO sysinfo;
@@ -258,8 +295,8 @@ JS_FN(mmap_incore) {
     free(result_data);
 
     v8::Local<v8::Array> arr = Nan::New<v8::Array>(2);
-    Nan::Set(arr, 0, Nan::New(pages_unmapped));
-    Nan::Set(arr, 1, Nan::New(pages_mapped));
+    Nan::Set(arr.As<v8::Object>(), 0, Nan::New(pages_unmapped).As<v8::Value>());
+    Nan::Set(arr.As<v8::Object>(), 1, Nan::New(pages_mapped).As<v8::Value>());
     info.GetReturnValue().Set(arr);
 }
 
@@ -276,8 +313,11 @@ JS_FN(mmap_sync_lib_private_) {
 
     if (!info[0]->IsObject())    return Nan::ThrowError("sync(): buffer (arg[0]) must be a Buffer");
 
-    Local<Object>   buf             = get_obj(info[0]); // info[0]->ToObject(); // get_v<Local<Object>>(info[0]);
-    char*           data            = node::Buffer::Data(buf);
+    char*   data;
+    size_t  buffer_size;  // Not used in this function but needed for get_buffer_info
+    if (!get_buffer_info(info[0], &data, &buffer_size)) {
+        return Nan::ThrowError("sync(): buffer (arg[0]) must be a Buffer or SharedArrayBuffer");
+    }
 
     int             offset          = get_v<int>(info[1], 0);
     size_t          length          = get_v<int>(info[2], 0);
@@ -307,7 +347,7 @@ NAN_MODULE_INIT(Init) {
         Nan::DefineOwnProperty(
             exports,
             Nan::New(key).ToLocalChecked(),
-            Nan::New(val),
+            Nan::New(val).As<v8::Value>(),
             std_property_attrs
         );
     };
@@ -316,7 +356,7 @@ NAN_MODULE_INIT(Init) {
         Nan::DefineOwnProperty(
             exports,
             Nan::New<v8::String>(key).ToLocalChecked(),
-            Nan::GetFunction(Nan::New<FunctionTemplate>(fn)).ToLocalChecked(),
+            Nan::GetFunction(Nan::New<FunctionTemplate>(fn)).ToLocalChecked().As<v8::Value>(),
             std_property_attrs
         );
     };
@@ -364,7 +404,7 @@ NAN_MODULE_INIT(Init) {
     Nan::DefineOwnProperty(
         exports,
         Nan::New<v8::String>("sync_lib_private__").ToLocalChecked(),
-        Nan::GetFunction(Nan::New<FunctionTemplate>(mmap_sync_lib_private_)).ToLocalChecked(),
+        Nan::GetFunction(Nan::New<FunctionTemplate>(mmap_sync_lib_private_)).ToLocalChecked().As<v8::Value>(),
         static_cast<PropertyAttribute>(0)
     );
 

--- a/src/mmap-io.ts
+++ b/src/mmap-io.ts
@@ -49,21 +49,21 @@ type MmapIo = {
         offset?: number,
         advise?: MapAdvise,
         name?: Buffer
-    ): SharedArrayBuffer
+    ): Uint8Array
 
     advise(
-        buffer: Buffer,
+        buffer: Buffer | SharedArrayBuffer | Uint8Array,
         offset: number,
         length: number,
         advise: MapAdvise
     ): void
-    advise(buffer: Buffer, advise: MapAdvise): void
+    advise(buffer: Buffer | SharedArrayBuffer | Uint8Array, advise: MapAdvise): void
 
     /// Returns tuple of [ unmapped-pages-count, mapped-pages-count ]
-    incore(buffer: Buffer): [number, number]
+    incore(buffer: Buffer | SharedArrayBuffer | Uint8Array): [number, number]
 
     sync(
-        buffer: Buffer,
+        buffer: Buffer | SharedArrayBuffer | Uint8Array,
         offset?: number,
         size?: number,
         blocking_sync?: boolean,
@@ -71,7 +71,7 @@ type MmapIo = {
     ): void
 
     sync(
-        buffer: Buffer,
+        buffer: Buffer | SharedArrayBuffer | Uint8Array,
         blocking_sync: boolean,
         invalidate_pages?: boolean
     ): void
@@ -102,19 +102,21 @@ delete mmap_lib_raw_.sync_lib_private__
 // Take care of all the param juggling here instead of in C++ code, by making
 // some overloads, and doing some argument defaults /ozra
 mmap_lib_raw_.sync = function(
-    buf: Buffer,
+    buf: Buffer | SharedArrayBuffer | Uint8Array,
     par_a?: any,
     par_b?: any,
     par_c?: any,
     par_d?: any
 ): void {
+    // Get the buffer size - use byteLength for SharedArrayBuffer/Uint8Array, length for Buffer
+    const bufSize = (buf instanceof SharedArrayBuffer || buf instanceof Uint8Array) ? buf.byteLength : (buf as Buffer).length;
     if (typeof par_a === "boolean") {
-        raw_sync_fn_(buf, 0, buf.length, par_a, par_b || false)
+        raw_sync_fn_(buf, 0, bufSize, par_a, par_b || false)
     } else {
         raw_sync_fn_(
             buf,
             par_a || 0,
-            par_b || buf.length,
+            par_b || bufSize,
             par_c || false,
             par_d || false
         )


### PR DESCRIPTION
* Update NAN to 2.23.1 for Node.js v25 support and update documentation
* Add V8 14.x compatibility fixes for Node.js v25 support
* Update C++ standard to C++20 for Node.js v23+ compatibility
* Fix SharedArrayBuffer compatibility: return Uint8Array and update test

---------

This is wholly implemented by Copilot Agent. I pulled in the code and [ran it against our limited mmap usage](https://github.com/serverless-dns/serverless-dns/blob/09546e6034610f9900195d73fecd29feb65429e9/src/core/node/blocklists.js#L78-L130) and it works on node v25.2.1 (modules v141):

```js
      const mmap = (await import("@riaskov/mmap-io")).default;
      const fd = fs.openSync(fp, "r+");
      const fsize = fs.fstatSync(fd).size;
      const rxprot = mmap.PROT_READ; // protection
      const mpriv = mmap.MAP_SHARED; // privacy
      const madv = mmap.MADV_RANDOM; // madvise
      const offset = 0;
      console.log("mmap f:", fp, "size:", fsize, "\nNOTE: md5 checks will fail");
      return mmap.map(fsize, rxprot, mpriv, fd, offset, madv);
```